### PR TITLE
Update networking_stack.py

### DIFF
--- a/mlops-multi-account-cdk/mlops-infra/mlops_infra/networking_stack.py
+++ b/mlops-multi-account-cdk/mlops-infra/mlops_infra/networking_stack.py
@@ -37,7 +37,7 @@ class NetworkingStack(Stack):
             subnet_configuration=[
                 ec2.SubnetConfiguration(
                     name="Private",
-                    subnet_type=ec2.SubnetType.PRIVATE_WITH_NAT,
+                    subnet_type=ec2.SubnetType.PRIVATE_WITH_EGRESS,
                     cidr_mask=24,
                 ),
                 ec2.SubnetConfiguration(name="Public", subnet_type=ec2.SubnetType.PUBLIC, cidr_mask=26),

--- a/mlops-multi-account-cdk/mlops-infra/mlops_infra/networking_stack.py
+++ b/mlops-multi-account-cdk/mlops-infra/mlops_infra/networking_stack.py
@@ -32,7 +32,7 @@ class NetworkingStack(Stack):
         self.primary_vpc = ec2.Vpc(
             self,
             "PrimaryVPC",
-            cidr="10.0.0.0/16",
+            ip_addresses=ec2.IpAddresses.cidr("10.0.0.0/16"),
             max_azs=3,
             subnet_configuration=[
                 ec2.SubnetConfiguration(


### PR DESCRIPTION
the aws-cdk-lib.aws_ec2.VpcProps#cidr is deprecated in favor of the ip_addresses parameter, and aws-cdk-lib.aws_ec2.SubnetType#PRIVATE_WITH_NAT is deprecated in favor of the aws-cdk-lib.aws_ec2.SubnetType#PRIVATE_WITH_EGRESS attribute. 

I have deployed the solution with these changes successfully.